### PR TITLE
Export var Polymer as implementation of an interface

### DIFF
--- a/polymer.d.ts
+++ b/polymer.d.ts
@@ -27,7 +27,12 @@ type Mixin<M> =
 /**
  * The Polymer function and namespace.
  */
-declare var Polymer: {
+declare var Polymer: Polymer;
+
+/**
+ * The Polymer Interface
+ */
+declare interface Polymer {
 
     /**
      * The "Polymer function" for backwards compatibility with Polymer 1.x.
@@ -68,7 +73,7 @@ declare var Polymer: {
     dom: (elem: HTMLElement) => any;
 
 
-};
+}
 
 declare interface PolymerElementConstructor {
     new(): PolymerElement;


### PR DESCRIPTION
Hi @aarondrabeck,
I was struggling with using legacy behaviors that declared var Polymer doesn't have (Polymer.IronFormElementBehavior, Polymer.PaperInputBehavior).

    ///<reference path="../../../bower_components/polymer2-ts/polymer.d.ts" />

    namespace EdiModules {

        class EdiPaperInput extends Polymer.mixinBehaviors([Polymer.IronFormElementBehavior, Polymer.PaperInputBehavior], EdiBase) {
            static get is() { return 'edi-paper-input'; }
        }

        customElements.define(EdiPaperInput.is, EdiPaperInput);
    }

I was thinking that it would be nice have var Polymer implementing an interface, because like that I can extend/modify that interface in order to add more properties.

    /// <reference path="../../../bower_components/polymer2-ts/polymer.d.ts" />

    interface Polymer {
        IronFormElementBehavior: IronFormElementBehavior;
        PaperInputBehavior: PaperInputBehavior;
    }

    declare interface IronFormElementBehavior {
        // ...
    }

    declare interface PaperInputBehavior {
        // ...
    }

    namespace EdiModules {

        class EdiPaperInput extends Polymer.mixinBehaviors([Polymer.IronFormElementBehavior, Polymer.PaperInputBehavior], EdiBase) {
            static get is() { return 'edi-paper-input'; }
        }

        customElements.define(EdiPaperInput.is, EdiPaperInput);
    }
#